### PR TITLE
fix: add recharts to packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "@lichtblick/suite": "workspace:*",
     "@mui/material": "5.13.5",
     "react-use": "17.5.1",
+    "recharts": "2.15.0",
     "rehype-raw": "6.1.1",
     "vm-browserify": "1.1.2"
   }


### PR DESCRIPTION
**User-Facing Changes**

**Description**
Add missing package `recharts` to build pie chart and bar graph

**Checklist**

- [x] The web version was tested and it is running ok
- [x] The desktop version was tested and it is running ok
- [ ] This change is covered by unit tests
- [ ] Files constants.ts, types.ts and *.style.ts have been checked and relevant code snippets have been relocated
